### PR TITLE
Update setup-new-repository steps to clarify when travis slack exists

### DIFF
--- a/SETUP-NEW-REPOSITORY.md
+++ b/SETUP-NEW-REPOSITORY.md
@@ -104,16 +104,16 @@ Assumes you've updated your respective project `.csproj` files with the necessar
 #### Add slack build notifications
 
 * Log into management section of slack `https://{organization}.slack.com/apps/manage`
-* Install/Update Travis CI app integration
-* Click 'Add Configuration'
-* Select your desired slack channel
-* Copy the generated slack token for next steps
+* If it doesn't exist already, install the Travis CI app integration
+    * Click 'Add Configuration'
+    * Select your desired slack channel
+* Copy the generated slack token from the Travic CI app integration for the next steps
 * Install travis cli client on your machine (if not already)
     * Ensure ruby 1.9.3+ is installed
     * `$: gem install travis --no-rdoc --no-ri`
 * Use the travis cli to generate a secure token
     * Reference [travis documentation](https://docs.travis-ci.com/user/notifications/#configuring-slack-notifications) if you run into any issues
     * Change directory (cd) to your repository (where the `.travis.yml` is located)
-    * `$: travis encrypt "{organization}:{slack-token}" --add notifications.slack.rooms`
+    * `$: travis encrypt "{organization}:{slack-token}" --add notifications.slack.rooms` (note: should be the 'slack' organization, not 'github')
     * This should automatically update the travis configuration with a secure token
 * For more information refer to [travis-ci documentation](https://docs.travis-ci.com/user/notifications/#configuring-slack-notifications)


### PR DESCRIPTION
Added clarity around travis slack integration for the following items:

1. Checking if Travis CI integration already exists in slack
2. To use the 'slack' organization, not github, when configuring the key with the CLI

**Checklist**
- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [x] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)
- [x] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
