### PR TITLE
Add dependabot config to update and-cli

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+    - package-ecosystem: "npm"
+      directory: "/"
+      schedule:
+          interval: "daily"
+      allow:
+          - dependency-name: "and-cli"


### PR DESCRIPTION
Related to #103 Add dependabot config to keep and-cli up-to-date across all repos (intentionally not linking w/ closing keywords)

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [-] Code formatted and follows best practices and patterns
- [-] Code builds cleanly (no _additional_ warnings or errors)
- [x] Manually tested
    - See PR generated by dependabot on my fork: https://github.com/brandongregoryscott/AndcultureCode/pull/4
- [-] Automated tests are passing
- [-] No _decreases_ in automated test coverage
- [-] Documentation updated (readme, docs, comments, etc.)
- [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
